### PR TITLE
fix: adjust Japanese header title font size and vertical alignment

### DIFF
--- a/localization.css
+++ b/localization.css
@@ -1,5 +1,5 @@
 /*
-	Sigma-10 Localization for JP)
+	Sigma-10 (Localization for JP)
 	[2025 Wikidot Theme]
 	Maintained by the JP SCP Wiki Technical Team, based on:
 
@@ -84,13 +84,13 @@
 
 /* stylelint-disable selector-class-pattern */
 
-/* プレビュー時のクレジットモジュールの表示崩れを修正 */
+/* プレビュー時のクレジット/Infoモジュールの表示崩れを修正 */
 .creditRate::before {
-	color: #000;
-	content: 'プレビュー時、クレジットモジュールは非表示となっています。表示を確認するには、一度保存してください。';
+	content: 'プレビュー時、クレジットモジュール・Infoモジュールは非表示となっています。\A表示を確認するには、一度保存してください。';
 	display: list-item;
 	font-weight: bold;
-	margin: 1.5rem 0;
+	margin: 1.5em 0;
+	white-space: pre;
 }
 
 .creditRate > li {

--- a/localization.css
+++ b/localization.css
@@ -28,8 +28,8 @@
 
 #header h1 a::after {
 	content: '財団';
-	font-size: 0.98em;
-	vertical-align: middle;
+	font-size: 0.95em;
+	vertical-align: -0.07em;
 }
 
 #header h1 a span {


### PR DESCRIPTION
"財団"の文字の配置を微調整しました。

Before
<img width="362" height="133" alt="image" src="https://github.com/user-attachments/assets/2be17cde-d1d5-48d7-9865-bb7deb7a5ee3" />

After
<img width="376" height="126" alt="image" src="https://github.com/user-attachments/assets/525333c1-caac-4fa8-8739-85c98812dbbc" />